### PR TITLE
Spawn mechanics

### DIFF
--- a/src/Model/Port.cpp
+++ b/src/Model/Port.cpp
@@ -1,0 +1,22 @@
+#include "Port.h"
+
+void Port::spawn(StarFighter* toRespawn)
+{
+	toRespawn->setPosition(this->position);
+	toRespawn->setAlive(true);
+}
+
+void Port::setPosition(Vector3 n_coord)
+{
+	this->position = n_coord;
+}
+
+void Port::setAlive(bool alive)
+{
+	this->alive = alive;
+}
+
+bool Port::getAlive()
+{
+	return this->alive;
+}

--- a/src/Model/Port.h
+++ b/src/Model/Port.h
@@ -1,0 +1,30 @@
+//Saves coordinates in which new ships spawns
+//spawnMethod - spawns new ship at this port coordinates
+
+#pragma once
+#include "StarFighter.h"
+#include "Transformable.h"
+class Port :public Transformable
+{
+public:
+	Port() {
+		this->position = Vector3(0, 0, 0);
+	}
+	Port(Vector3 coord) {
+		this->position = coord;
+	}
+	~Port() {}
+
+	//Spawn method
+	void spawn(StarFighter* toRespawn);
+
+	//setMethod
+	void setPosition(Vector3 n_coord);
+	void setAlive(bool alive);
+
+	//getMethod
+	bool getAlive();
+protected:
+	bool alive;
+};
+

--- a/src/Model/Queue.cpp
+++ b/src/Model/Queue.cpp
@@ -1,0 +1,65 @@
+#include "Queue.h"
+
+void Queue::setMaxAmount(int maxAmount)
+{
+	this->maxAmount = maxAmount;
+}
+
+void Queue::setPortAmount(int portAmount)
+{
+	this->portAmount = portAmount;
+}
+
+void Queue::setRespawnTime(float respawnTime)
+{
+	this->respawnTime = respawnTime;
+}
+
+void Queue::update(float dt)
+{
+
+	//Check if any ships are dead
+	for (int i = 0; i < aliveQueue.size(); i++)
+	{
+		if (aliveQueue[i]->getAlive() == false)
+		{
+			respawnQueue.push(aliveQueue[i]);
+			aliveQueue.erase(aliveQueue.begin() + i);
+		}
+	}
+	//Check if any ports are dead
+	for (int i = 0; i < ports.size(); i++)
+	{
+		if (ports[i].getAlive() == false)
+		{
+			ports.erase(ports.begin() + i);
+			this->portAmount = ports.size();
+		}
+	}
+
+	this->estimatedTime += dt;
+
+	//Check ability for spawn
+	if (this->estimatedTime >= this->respawnTime && !this->respawnQueue.empty()) {
+
+		//Spawn first object from respawn queue
+		spawn(this->respawnQueue.front(), getPortNum());
+
+		//Delete first object from respawn queue
+		aliveQueue.push_back(respawnQueue.front());
+		respawnQueue.pop();
+		this->estimatedTime = 0;
+	}
+
+};
+
+void Queue::spawn(StarFighter* toRespawn, int portNumber)
+{
+	this->ports[portNumber].spawn(toRespawn);
+}
+
+int Queue::getPortNum()
+{
+	int portNum = std::rand() % this->ports.size();
+	return portNum;
+}

--- a/src/Model/Queue.h
+++ b/src/Model/Queue.h
@@ -1,0 +1,76 @@
+#pragma once
+#include "StarFighter.h"
+#include <queue>
+#include "Port.h"
+
+class Queue
+{
+public:
+
+	//Constructors
+	Queue() {
+		this->maxAmount = 0;
+		this->portAmount = 0;
+		this->respawnTime = 0.f;
+		this->estimatedTime = 0.f;
+	}
+
+	Queue(int maxAmount, int portAmount, float respawnTime) {
+
+		this->maxAmount = maxAmount;
+		this->portAmount = portAmount;
+		this->respawnTime = respawnTime;
+		this->estimatedTime = 0;
+		StarFighter* p = nullptr;
+		for (int i = 0; i < portAmount; i++) ports.push_back(Port());
+		for (int i = 0; i < maxAmount; i++) {
+			p = new StarFighter();
+			aliveQueue.push_back(p);
+			spawn(p, getPortNum());
+		}
+	}
+
+	~Queue()
+	{
+		for (int i = 0; i < aliveQueue.size(); i++) delete aliveQueue[i];
+		if (!respawnQueue.empty())	for (int i = 0; i < respawnQueue.size(); i++) delete respawnQueue.front();
+		aliveQueue.clear();
+		ports.clear();
+	}
+
+	//setMethods
+	void setMaxAmount(int maxAmount);
+	void setPortAmount(int portAmount);
+	void setRespawnTime(float respawnTime);
+
+	//Update method
+	void update(float dt);
+
+	//Spawn method
+	void spawn(StarFighter* toRespawn, int portNumber);
+
+protected:
+
+	int getPortNum();
+
+	//Queue of ships waiting for respawn
+	std::queue <StarFighter*> respawnQueue;
+
+	//Queue of ships in the air
+	std::vector <StarFighter*> aliveQueue;
+
+	//Alive ports
+	std::vector <Port> ports;
+
+
+	int maxAmount;
+	int portAmount;
+
+	//Time in which new ship spawns
+	float respawnTime;
+
+	//Time estimated since last spawn
+	float estimatedTime;
+
+};
+


### PR DESCRIPTION
Added Queue and Port
To operate correcly variable alive for port and starfighter must be declared

To do:
- Each spawn locate spawn point in range of port to avoid collisions between starfighters